### PR TITLE
Update first header

### DIFF
--- a/src/features/delete-selected-files/delete-selected-files.manager.ts
+++ b/src/features/delete-selected-files/delete-selected-files.manager.ts
@@ -1,24 +1,25 @@
+import { Notice } from "obsidian";
 import { Settings } from "src/interfaces/settings";
-import FileExplorerProPlugin from "src/main";
+import { FileExplorerProPlugin } from "src/main";
 
 export class DeleteSelectedFilesManager {
   commandId = 'delete-selected-files';
-  name = 'Delete Selected Files in File Explorer';
+  commandName = 'Delete Selected Files in File Explorer';
 
   constructor(private plugin: FileExplorerProPlugin) {
 
   }
 
   init(settings: Settings) {
-    if (settings.enableDeleteSelectedFiles) {
-      this.registerCommand();
-    }
+    if (!settings.enableDeleteSelectedFiles) return;
+
+    this.registerCommand();
   }
 
   private registerCommand() {
     this.plugin.addCommand({
       id: this.commandId,
-      name: this.name,
+      name: this.commandName,
       hotkeys: [{ modifiers: ["Alt"], key: "delete" }],
       callback: () => this.deleteSelectedFiles()
     });
@@ -40,7 +41,8 @@ export class DeleteSelectedFilesManager {
       try {
         await this.plugin.app.fileManager.trashFile(file);
       } catch (error) {
-        console.error(error);
+        console.error({ message: 'Failed to delete file', file, error });
+        new Notice('Failed to delete file');
       }
     }
   }

--- a/src/features/reveal-active-file/reveal-active-file.manager.ts
+++ b/src/features/reveal-active-file/reveal-active-file.manager.ts
@@ -1,5 +1,4 @@
-import { Settings } from "src/interfaces/settings";
-import FileExplorerProPlugin from "src/main";
+import { FileExplorerProPlugin } from "src/main";
 import { CommandIds } from "src/obsidian/obsidian-constants";
 import { ElementFactory } from "src/utils/element-factory";
 import { Icons } from "src/utils/icons";
@@ -13,12 +12,7 @@ export class RevealActiveFileManager {
 
   constructor(private plugin: FileExplorerProPlugin) { }
 
-  init(settings: Settings) {
-    this.showFileExplorerRevealButton(settings.showFileExplorerRevealButton);
-    this.showViewActionsRevealButton(settings.showViewActionsRevealButton);
-  }
-
-  private showFileExplorerRevealButton(show: boolean) {
+  showFileExplorerRevealButton(show: boolean) {
     // - This happens when user change the settings, we need to remove the existing button
     // > User want to hide button, but button exists. We need to remove it
     if (!show && this.fileExplorerRevealButton) {
@@ -53,20 +47,31 @@ export class RevealActiveFileManager {
     this.fileExplorerRevealButton = button;
   }
 
-  private showViewActionsRevealButton(show: boolean) {
-    // - This happens when user change the settings, we need to remove the existing button
-    // > User want to hide button, but button exists. We need to remove it
-    if (!show && this.viewActionsRevealButton) {
+  /**
+   * - Show view actions only when:
+   *   + Enabled in the settings
+   *   + And, any file is opened
+   * @param show 
+   * @returns 
+   */
+  showViewActionsRevealButton(show: boolean) {
+
+    const isFileOpened = !!this.plugin.getActiveFile();
+
+    // > User want to hide button or no file is opened, but button exists. We need to remove it
+    if ((!show || !isFileOpened) && this.viewActionsRevealButton) {
       this.viewActionsRevealButton.remove();
       this.viewActionsRevealButton = undefined;
       return;
     }
-    // > User want to user button and button already exists
-    else if (show && this.viewActionsRevealButton) {
-      return;
-    }
-    // > User want to hide the button, and button not exists. Nothing to do
-    else if (!show) {
+    else if (
+      // > User want to user button and button already exists. Nothing to do
+      (show && this.viewActionsRevealButton) ||
+      // > User want to hide the button, and button not exists. Nothing to do
+      !show ||
+      // > No file opened
+      !isFileOpened
+    ) {
       return;
     }
 
@@ -74,7 +79,7 @@ export class RevealActiveFileManager {
     const container = this.plugin.getViewActionsContainer();
     if (!container) {
       // This technically should not happen
-      console.error('File Explorer not found');
+      console.error('View Actions not found');
       return;
     }
 

--- a/src/features/update-first-header/update-first-header.manager.ts
+++ b/src/features/update-first-header/update-first-header.manager.ts
@@ -1,0 +1,73 @@
+import { Notice, TFile } from "obsidian";
+import { Settings } from "src/interfaces/settings";
+import { FileExplorerProPlugin } from "src/main";
+
+export class UpdateFirstHeaderManager {
+  commandId = 'update-first-header';
+  commandName = 'Update First Header to File Name';
+
+  constructor(private plugin: FileExplorerProPlugin) {
+
+  }
+
+  init(settings: Settings) {
+    // - Add update file header command
+    this.registerCommand(settings);
+
+    // - Listen to file rename event
+    this.autoRename(settings);
+  }
+
+  private registerCommand(settings: Settings) {
+    if (!settings.addUpdateFirstHeaderCommand) return;
+
+    this.plugin.addCommand({
+      id: this.commandId,
+      name: this.commandName,
+      hotkeys: [{ modifiers: ["Alt"], key: "h" }],
+      checkCallback: (checking) => {
+        if (checking) {
+          return !!this.plugin.getActiveFile();
+        }
+
+        this.renameThisFileFirstHeader();
+      }
+    });
+  }
+
+  private autoRename(settings: Settings) {
+    if (!settings.autoUpdateFirstHeader) return;
+
+    this.plugin.registerEvent(
+      this.plugin.app.vault.on('rename', this.renameHeader.bind(this))
+    );
+  }
+
+  private renameThisFileFirstHeader() {
+    this.renameHeader(this.plugin.getActiveFile());
+  }
+
+  private async renameHeader(file: TFile | null) {
+    try {
+      if (!file) return;
+
+      // - If ignore timestamp is enabled, remove all numbers at the beginning
+      let heading = file.basename;
+      if (this.plugin.settings.ignoreTimestamp) {
+        heading = heading.replace(/[0-9-_]*/, '');
+      }
+
+      // - Read the file as text
+      let markdownContent = await this.plugin.app.vault.read(file);
+
+      // - Replace first heading with the new heading
+      markdownContent = markdownContent.replace(/#\s.*/, `# ${heading}`);
+
+      // - Write back to the file
+      await this.plugin.app.vault.modify(file, markdownContent);
+    } catch (error) {
+      console.error({ message: 'Failed to rename header', file, error });
+      new Notice('Failed to rename header');
+    }
+  }
+}

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -1,5 +1,13 @@
 export interface Settings {
+  // - Reveal active file
   showFileExplorerRevealButton: boolean;
   showViewActionsRevealButton: boolean;
+
+  // - Delete selected files
   enableDeleteSelectedFiles: boolean;
+
+  // - Update first file header
+  autoUpdateFirstHeader: boolean;
+  addUpdateFirstHeaderCommand: boolean;
+  ignoreTimestamp: boolean;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Plugin } from 'obsidian';
 import { DeleteSelectedFilesManager } from './features/delete-selected-files/delete-selected-files.manager';
 import { RevealActiveFileManager } from './features/reveal-active-file/reveal-active-file.manager';
+import { UpdateFirstHeaderManager } from './features/update-first-header/update-first-header.manager';
 import { Settings } from './interfaces/settings';
 import { HtmlSelector } from './obsidian/obsidian-constants';
 import { SettingTab } from './settings/setting-tab';
@@ -10,13 +11,17 @@ const DEFAULT_SETTINGS: Settings = {
 	showFileExplorerRevealButton: true,
 	showViewActionsRevealButton: true,
 	enableDeleteSelectedFiles: true,
+	addUpdateFirstHeaderCommand: true,
+	autoUpdateFirstHeader: true,
+	ignoreTimestamp: true,
 };
 
-export default class FileExplorerProPlugin extends Plugin {
+export class FileExplorerProPlugin extends Plugin {
 	settings: Settings;
 
 	revealActiveFileManager: RevealActiveFileManager;
 	deleteSelectedFilesManager: DeleteSelectedFilesManager;
+	updateFirstHeaderManager: UpdateFirstHeaderManager;
 
 	async onload() {
 		await this.loadSettings();
@@ -24,12 +29,21 @@ export default class FileExplorerProPlugin extends Plugin {
 		// - Add reveal file button to file explorer
 		this.revealActiveFileManager = new RevealActiveFileManager(this);
 		this.app.workspace.onLayoutReady(() => {
-			this.revealActiveFileManager.init(this.settings);
+			this.revealActiveFileManager.showFileExplorerRevealButton(this.settings.showFileExplorerRevealButton);
+		});
+
+		// - Show reveal file button to view actions only if some file is opened
+		this.app.workspace.on('layout-change', () => {
+			this.revealActiveFileManager.showViewActionsRevealButton(this.settings.showViewActionsRevealButton);
 		});
 
 		// - Add delete selected items command
 		this.deleteSelectedFilesManager = new DeleteSelectedFilesManager(this);
 		this.deleteSelectedFilesManager.init(this.settings);
+
+		// - Auto rename file header
+		this.updateFirstHeaderManager = new UpdateFirstHeaderManager(this);
+		this.updateFirstHeaderManager.init(this.settings);
 
 		// - Add obsidian setting page
 		this.addSettingTab(new SettingTab(this.app, this));
@@ -55,6 +69,10 @@ export default class FileExplorerProPlugin extends Plugin {
 		return this.getMarkdown()?.view.containerEl.querySelector(HtmlSelector.ViewActionsContainer);
 	}
 
+	getActiveFile() {
+		return this.app.workspace.getActiveFile();
+	}
+
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 	}
@@ -64,4 +82,4 @@ export default class FileExplorerProPlugin extends Plugin {
 	}
 }
 
-
+export default FileExplorerProPlugin;

--- a/src/settings/setting-tab.ts
+++ b/src/settings/setting-tab.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
-import FileExplorerProPlugin from '../main';
+import { FileExplorerProPlugin } from '../main';
 
 export class SettingTab extends PluginSettingTab {
   plugin: FileExplorerProPlugin;
@@ -13,8 +13,9 @@ export class SettingTab extends PluginSettingTab {
     const { containerEl } = this;
 
     containerEl.empty();
+    containerEl.createEl('h2', { text: 'File Explorer Pro Settings' });
 
-    containerEl.createEl('h2', { text: 'General Settings' });
+    containerEl.createEl('h3', { text: 'Reveal Active File' });
 
     new Setting(containerEl)
       .setName('Show Reveal Active File Button in File Explorer')
@@ -22,7 +23,7 @@ export class SettingTab extends PluginSettingTab {
         .setValue(this.plugin.settings.showFileExplorerRevealButton)
         .onChange(async (value) => {
           this.plugin.settings.showFileExplorerRevealButton = value;
-          this.plugin.revealActiveFileManager.init(this.plugin.settings);
+          this.plugin.revealActiveFileManager.showFileExplorerRevealButton(value);
           await this.plugin.saveSettings();
         }));
 
@@ -32,16 +33,60 @@ export class SettingTab extends PluginSettingTab {
         .setValue(this.plugin.settings.showFileExplorerRevealButton)
         .onChange(async (value) => {
           this.plugin.settings.showViewActionsRevealButton = value;
-          this.plugin.revealActiveFileManager.init(this.plugin.settings);
+          this.plugin.revealActiveFileManager.showViewActionsRevealButton(value);
           await this.plugin.saveSettings();
         }));
 
+    containerEl.createEl('h3', { text: 'Delete Selected Files' });
+
     new Setting(containerEl)
-      .setName('Enable Alt+Delete to Delete Selected Files in File Explorer')
+      .setName('Enable Delete Selected Files')
+      .setDesc(
+        'Requires restart obsidian. ' +
+        'Add a command to delete selected files in file explorer. ' +
+        'Default hotkey is "Alt+Delete". ')
       .addToggle(toggle => toggle
         .setValue(this.plugin.settings.enableDeleteSelectedFiles)
         .onChange(async (value) => {
           this.plugin.settings.enableDeleteSelectedFiles = value;
+          await this.plugin.saveSettings();
+        }));
+
+    containerEl.createEl('h3', { text: 'Auto File Header' });
+
+    new Setting(containerEl)
+      .setName('Add Update First File Header Command')
+      .setDesc(
+        'Requires restart obsidian. ' +
+        'Add a command to automatically update first header to the current file name. ')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.addUpdateFirstHeaderCommand)
+        .onChange(async (value) => {
+          this.plugin.settings.addUpdateFirstHeaderCommand = value;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName('Auto Update First File Header')
+      .setDesc(
+        'Requires restart obsidian. ' +
+        'Automatically run the command to update first header when file rename. ')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.autoUpdateFirstHeader)
+        .onChange(async (value) => {
+          this.plugin.settings.autoUpdateFirstHeader = value;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName('Ignore Timestamp in File Name')
+      .setDesc(
+        'First header will ignore the timestamp in the file name. ' +
+        'E.g. Remove random number or timestamp at the beginning of the file name')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.ignoreTimestamp)
+        .onChange(async (value) => {
+          this.plugin.settings.ignoreTimestamp = value;
           await this.plugin.saveSettings();
         }));
   }


### PR DESCRIPTION
## New
### Update first header
- Add command to update first file header according to file name. Default hotkey `Alt + H`
- Add function to automatically run above command on file rename
- Allow user to remove timestamp at the beginning of the file name

### Updated
- `Reveal Active File` button in view action should hide when no file is opened
- Updated some setting description

## Bug fixes
- `Reveal Active File` button in view action sometimes not shown properly