### PR TITLE
Smarter file rename

### DIFF
--- a/src/features/delete-selected-files/delete-selected-files.manager.ts
+++ b/src/features/delete-selected-files/delete-selected-files.manager.ts
@@ -41,8 +41,9 @@ export class DeleteSelectedFilesManager {
       try {
         await this.plugin.app.fileManager.trashFile(file);
       } catch (error) {
-        console.error({ message: 'Failed to delete file', file, error });
-        new Notice('Failed to delete file');
+        const message = 'Failed to delete file';
+        console.error({ message, file, error });
+        new Notice(message);
       }
     }
   }

--- a/src/features/smarter-file-rename/smarter-file-rename.manager.ts
+++ b/src/features/smarter-file-rename/smarter-file-rename.manager.ts
@@ -1,0 +1,66 @@
+import { Notice } from "obsidian";
+import { Settings } from "src/interfaces/settings";
+import { FileExplorerProPlugin } from "src/main";
+import { CommandIds, ViewType } from "src/obsidian/obsidian-constants";
+
+export class SmarterFileRenameManager {
+  commandId = 'smarter-file-rename';
+  commandName = 'Smarter File Rename';
+
+  constructor(private plugin: FileExplorerProPlugin) {
+
+  }
+
+  init(settings: Settings) {
+    if (!settings.enableSmarterFileRename) return;
+
+    this.plugin.addCommand({
+      id: this.commandId,
+      name: this.commandName,
+      hotkeys: [{ modifiers: ['Alt'], key: "F2" }],
+      checkCallback: (checking) => {
+        const activeLeaf = this.plugin.app.workspace.activeLeaf;
+        if (!activeLeaf) return false;
+
+        const viewType = activeLeaf.view.getViewType();
+        if (checking) {
+          return viewType === ViewType.FileExplorer || viewType === ViewType.Markdown;
+        }
+
+        if (viewType === ViewType.FileExplorer) {
+          this.renameFile();
+        }
+        else if (viewType === ViewType.Markdown) {
+          this.editFileTitle();
+        }
+      }
+    });
+  }
+
+  editFileTitle() {
+    this.plugin.app.commands.executeCommandById(CommandIds.Workspace.EditFileTitle);
+  }
+
+  private async renameFile() {
+    const fileExplorer = this.plugin.getFileExplorer();
+    if (!fileExplorer) {
+      console.error('File explorer not found');
+      return;
+    }
+
+    const activeDom = fileExplorer.view.activeDom;
+    if (!activeDom) {
+      new Notice('Please select the file to rename in file explorer');
+      return;
+    }
+
+    const file = activeDom.file;
+    try {
+      await fileExplorer.view.startRenameFile(file);
+    } catch (error) {
+      const message = 'Failed to start rename';
+      console.error({ message, file, error });
+      new Notice(message);
+    }
+  }
+}

--- a/src/features/update-first-header/update-first-header.manager.ts
+++ b/src/features/update-first-header/update-first-header.manager.ts
@@ -56,24 +56,26 @@ export class UpdateFirstHeaderManager {
 
     const file = <TFile>renamedItem;
 
+
+    // - If ignore timestamp is enabled, remove all numbers at the beginning
+    let heading = file.basename;
+    if (this.plugin.settings.ignoreTimestamp) {
+      heading = heading.replace(/[0-9-_]*/, '');
+    }
+
+    // - Read the file as text
+    let markdownContent = await this.plugin.app.vault.read(file);
+
+    // - Replace first heading with the new heading
+    markdownContent = markdownContent.replace(/#\s.*/, `# ${heading}`);
+
+    // - Write back to the file
     try {
-      // - If ignore timestamp is enabled, remove all numbers at the beginning
-      let heading = file.basename;
-      if (this.plugin.settings.ignoreTimestamp) {
-        heading = heading.replace(/[0-9-_]*/, '');
-      }
-
-      // - Read the file as text
-      let markdownContent = await this.plugin.app.vault.read(file);
-
-      // - Replace first heading with the new heading
-      markdownContent = markdownContent.replace(/#\s.*/, `# ${heading}`);
-
-      // - Write back to the file
       await this.plugin.app.vault.modify(file, markdownContent);
     } catch (error) {
-      console.error({ message: 'Failed to rename header', file, error });
-      new Notice('Failed to rename header');
+      const message = 'Failed to rename header';
+      console.error({ message, file, error });
+      new Notice(message);
     }
   }
 }

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -10,4 +10,7 @@ export interface Settings {
   autoUpdateFirstHeader: boolean;
   addUpdateFirstHeaderCommand: boolean;
   ignoreTimestamp: boolean;
+
+  // - Smarter file rename
+  enableSmarterFileRename: boolean;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Plugin } from 'obsidian';
 import { DeleteSelectedFilesManager } from './features/delete-selected-files/delete-selected-files.manager';
 import { RevealActiveFileManager } from './features/reveal-active-file/reveal-active-file.manager';
+import { SmarterFileRenameManager } from './features/smarter-file-rename/smarter-file-rename.manager';
 import { UpdateFirstHeaderManager } from './features/update-first-header/update-first-header.manager';
 import { Settings } from './interfaces/settings';
 import { HtmlSelector } from './obsidian/obsidian-constants';
@@ -14,6 +15,7 @@ const DEFAULT_SETTINGS: Settings = {
 	addUpdateFirstHeaderCommand: true,
 	autoUpdateFirstHeader: true,
 	ignoreTimestamp: true,
+	enableSmarterFileRename: true,
 };
 
 export class FileExplorerProPlugin extends Plugin {
@@ -22,13 +24,18 @@ export class FileExplorerProPlugin extends Plugin {
 	revealActiveFileManager: RevealActiveFileManager;
 	deleteSelectedFilesManager: DeleteSelectedFilesManager;
 	updateFirstHeaderManager: UpdateFirstHeaderManager;
+	smarterFileRenameManager: SmarterFileRenameManager;
 
 	async onload() {
 		await this.loadSettings();
 
-		// - Add reveal file button to file explorer
 		this.revealActiveFileManager = new RevealActiveFileManager(this);
+		this.deleteSelectedFilesManager = new DeleteSelectedFilesManager(this);
+		this.updateFirstHeaderManager = new UpdateFirstHeaderManager(this);
+		this.smarterFileRenameManager = new SmarterFileRenameManager(this);
+
 		this.app.workspace.onLayoutReady(() => {
+			// - Add reveal file button to file explorer
 			this.revealActiveFileManager.showFileExplorerRevealButton(this.settings.showFileExplorerRevealButton);
 		});
 
@@ -38,12 +45,13 @@ export class FileExplorerProPlugin extends Plugin {
 		});
 
 		// - Add delete selected items command
-		this.deleteSelectedFilesManager = new DeleteSelectedFilesManager(this);
 		this.deleteSelectedFilesManager.init(this.settings);
 
 		// - Auto rename file header
-		this.updateFirstHeaderManager = new UpdateFirstHeaderManager(this);
 		this.updateFirstHeaderManager.init(this.settings);
+
+		// - Smarter rename file
+		this.smarterFileRenameManager.init(this.settings);
 
 		// - Add obsidian setting page
 		this.addSettingTab(new SettingTab(this.app, this));

--- a/src/obsidian/obsidian-constants.ts
+++ b/src/obsidian/obsidian-constants.ts
@@ -1,3 +1,10 @@
+// - View type can be found in html search for `data-type`
+export const ViewType = {
+  Search: 'search',
+  FileExplorer: 'file-explorer',
+  Markdown: 'markdown'
+};
+
 export const HtmlSelector = {
   NavButtonsContainer: 'div.nav-buttons-container',
   ViewActionsContainer: 'div.view-actions'
@@ -6,6 +13,9 @@ export const HtmlSelector = {
 // - Command ids can be found in `plugin.app.commands`
 export const CommandIds = {
   FileExplorer: {
-    RevealActiveFile: 'file-explorer:reveal-active-file'
+    RevealActiveFile: 'file-explorer:reveal-active-file',
+  },
+  Workspace: {
+    EditFileTitle: 'workspace:edit-file-title',
   }
 };

--- a/src/obsidian/obsidian.d.ts
+++ b/src/obsidian/obsidian.d.ts
@@ -26,7 +26,9 @@ interface FileExplorerLeaf extends WorkspaceLeaf {
 }
 
 interface FileExplorerView extends View {
+  activeDom: FileExplorerDom | null;
   selectedDoms: FileExplorerDom[];
+  startRenameFile(file: TFile): Promise<void>;
 }
 
 interface FileExplorerDom {

--- a/src/settings/setting-tab.ts
+++ b/src/settings/setting-tab.ts
@@ -30,7 +30,7 @@ export class SettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Show Reveal Active File Button in View Actions')
       .addToggle(toggle => toggle
-        .setValue(this.plugin.settings.showFileExplorerRevealButton)
+        .setValue(this.plugin.settings.showViewActionsRevealButton)
         .onChange(async (value) => {
           this.plugin.settings.showViewActionsRevealButton = value;
           this.plugin.revealActiveFileManager.showViewActionsRevealButton(value);
@@ -44,7 +44,7 @@ export class SettingTab extends PluginSettingTab {
       .setDesc(
         'Requires restart obsidian. ' +
         'Add a command to delete selected files in file explorer. ' +
-        'Default hotkey is "Alt+Delete". ')
+        'Default hotkey is "Alt + Delete". ')
       .addToggle(toggle => toggle
         .setValue(this.plugin.settings.enableDeleteSelectedFiles)
         .onChange(async (value) => {
@@ -87,6 +87,23 @@ export class SettingTab extends PluginSettingTab {
         .setValue(this.plugin.settings.ignoreTimestamp)
         .onChange(async (value) => {
           this.plugin.settings.ignoreTimestamp = value;
+          await this.plugin.saveSettings();
+        }));
+
+    containerEl.createEl('h3', { text: 'Rename file' });
+
+    new Setting(containerEl)
+      .setName('Enable Smarter File Rename')
+      .setDesc(
+        'Requires restart obsidian. ' +
+        'Add a command to make rename smarter. ' +
+        'Rename file when focus on file explorer. ' +
+        'Edit file title when focus on markdown editor. ' +
+        'Default hot key is "Alt + F2". You can remap hotkey in settings to "F2", make it replace "Edit file title".')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.enableSmarterFileRename)
+        .onChange(async (value) => {
+          this.plugin.settings.enableSmarterFileRename = value;
           await this.plugin.saveSettings();
         }));
   }


### PR DESCRIPTION
## New
### Smarter file rename
- Add a command to make rename smarter. Default hotkey is `Alt + F2`.
- Edit file title when focus on the markdown editor
- Rename file when focus on the file explorer
- You can remap hotkey in settings to `F2`, make it replace `Edit file title`.

## Updates
- Better error logging